### PR TITLE
perf: only load user state when showing full user data

### DIFF
--- a/js/src/forum/components/UserPoliciesStateModal.js
+++ b/js/src/forum/components/UserPoliciesStateModal.js
@@ -2,10 +2,29 @@ import app from 'flarum/forum/app';
 import humanTime from 'flarum/common/helpers/humanTime';
 import Modal from 'flarum/common/components/Modal';
 import sortByAttribute from '../../common/helpers/sortByAttribute';
+import LoadingIndicator from 'flarum/common/components/LoadingIndicator';
 
 /* global m */
 
 export default class UserPoliciesStateModal extends Modal {
+  user = null;
+  loading = false;
+
+  oninit(vnode) {
+    super.oninit(vnode);
+
+    if (this.attrs.user.fofTermsPoliciesState() === undefined) {
+      this.loading = true;
+      app.store.find('users', this.attrs.user.id()).then((user) => {
+        this.user = user;
+        this.loading = false;
+        m.redraw();
+      });
+    } else {
+      this.user = this.attrs.user;
+    }
+  }
+
   title() {
     return app.translator.trans('fof-terms.forum.state-modal.title', {
       username: this.attrs.user.username(),
@@ -13,12 +32,20 @@ export default class UserPoliciesStateModal extends Modal {
   }
 
   content() {
+    if (this.loading) {
+      return (
+        <div className="Modal-body">
+          <LoadingIndicator />
+        </div>
+      );
+    }
+
     return m(
       '.Modal-body',
       m(
         'ul',
         sortByAttribute(app.store.all('fof-terms-policies')).map((policy) => {
-          const state = this.attrs.user.fofTermsPoliciesState()[policy.id()];
+          const state = this.user.fofTermsPoliciesState()[policy.id()];
 
           return m('li', [
             policy.name() + ': ',

--- a/src/Extenders/UserPoliciesRelationship.php
+++ b/src/Extenders/UserPoliciesRelationship.php
@@ -12,6 +12,7 @@
 namespace FoF\Terms\Extenders;
 
 use Flarum\Api\Serializer\BasicUserSerializer;
+use Flarum\Api\Serializer\CurrentUserSerializer;
 use Flarum\User\User;
 use FoF\Terms\Repositories\PolicyRepository;
 
@@ -33,6 +34,9 @@ class UserPoliciesRelationship
 
         if ($request->getAttribute('routeName') === 'users.show' && $serializer->getActor()->can('seeFoFTermsPoliciesState', $user)) {
             $attributes['fofTermsPoliciesState'] = $this->policies->state($user);
+        }
+
+        if ($serializer instanceof CurrentUserSerializer) {
             $attributes['fofTermsPoliciesHasUpdate'] = $this->policies->hasPoliciesUpdate($user);
             $attributes['fofTermsPoliciesMustAccept'] = $this->policies->mustAcceptNewPolicies($user);
         }

--- a/src/Extenders/UserPoliciesRelationship.php
+++ b/src/Extenders/UserPoliciesRelationship.php
@@ -29,7 +29,9 @@ class UserPoliciesRelationship
 
     public function __invoke(BasicUserSerializer $serializer, User $user, array $attributes)
     {
-        if ($serializer->getActor()->can('seeFoFTermsPoliciesState', $user)) {
+        $request = $serializer->getRequest();
+
+        if ($request->getAttribute('routeName') === 'users.show' && $serializer->getActor()->can('seeFoFTermsPoliciesState', $user)) {
             $attributes['fofTermsPoliciesState'] = $this->policies->state($user);
             $attributes['fofTermsPoliciesHasUpdate'] = $this->policies->hasPoliciesUpdate($user);
             $attributes['fofTermsPoliciesMustAccept'] = $this->policies->mustAcceptNewPolicies($user);


### PR DESCRIPTION
Fof terms only needs the serialized state for the modal to see if a user accepted, this can be optimized by lazy loading the full user data from the modal.

The other attributes are only needed for the current user serialization.

This prevents unnecessary querying of the terms state when serializing discussion & post authors in other endpoints. Solves a massive slowdown with big data.