### PR TITLE
chore: add IDE configuration files to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@ js/node_modules
 vendor/
 composer.lock
 js/dist
+
+.idea
+.fleet
+.vscode
+.zed


### PR DESCRIPTION
As in the title. To avoid accidentally committing these files.