### PR TITLE
fix: Prevent loading user policies on post lists

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -12,7 +12,7 @@
 namespace FoF\Terms;
 
 use Flarum\Api\Controller\ShowForumController;
-use Flarum\Api\Serializer\BasicUserSerializer;
+use Flarum\Api\Serializer\UserSerializer;
 use Flarum\Api\Serializer\ForumSerializer;
 use Flarum\Database\AbstractModel;
 use Flarum\Extend;
@@ -60,7 +60,7 @@ return [
         ->modelPolicy(Policy::class, Access\PolicyPolicy::class)
         ->modelPolicy(User::class, Access\UserPolicy::class),
 
-    (new Extend\ApiSerializer(BasicUserSerializer::class))
+    (new Extend\ApiSerializer(UserSerializer::class))
         ->attributes(Extenders\UserPoliciesRelationship::class),
 
     (new Extend\Settings())

--- a/src/Extenders/UserPoliciesRelationship.php
+++ b/src/Extenders/UserPoliciesRelationship.php
@@ -11,7 +11,8 @@
 
 namespace FoF\Terms\Extenders;
 
-use Flarum\Api\Serializer\BasicUserSerializer;
+use Flarum\Api\Controller\ListPostsController;
+use Flarum\Api\Serializer\UserSerializer;
 use Flarum\User\User;
 use FoF\Terms\Repositories\PolicyRepository;
 
@@ -27,8 +28,12 @@ class UserPoliciesRelationship
         $this->policies = $policies;
     }
 
-    public function __invoke(BasicUserSerializer $serializer, User $user, array $attributes)
+    public function __invoke(UserSerializer $serializer, User $user, array $attributes): array
     {
+        if ($serializer->getRequest()->getAttribute('controller') === ListPostsController::class) {
+            return $attributes;
+        }
+
         if ($serializer->getActor()->can('seeFoFTermsPoliciesState', $user)) {
             $attributes['fofTermsPoliciesState'] = $this->policies->state($user);
             $attributes['fofTermsPoliciesHasUpdate'] = $this->policies->hasPoliciesUpdate($user);


### PR DESCRIPTION
Loading user policies on post lists causes a significant performance issue (N+1 query problem).

This commit fixes the issue by moving the policy-related attributes from the BasicUserSerializer to the UserSerializer. This ensures that the policies are only loaded for full user profiles and not for the post author's basic information.

An additional check is added to prevent loading the policies even if the UserSerializer is used in the ListPostsController.

Fixes #0000

Changes proposed in this pull request:

Modified extend.php to move the UserPoliciesRelationship extender from BasicUserSerializer to UserSerializer. This prevents the policy attributes from being loaded for every post author in a list.

Updated src/Extenders/UserPoliciesRelationship.php to add a safeguard that prevents policy loading when the ListPostsController is used, even with UserSerializer.

The main impacted area is the API endpoint for listing posts (/api/posts), which should now be significantly faster when fof/terms is enabled.

Reviewers should focus on:

Ensuring that moving the attributes from BasicUserSerializer to UserSerializer does not negatively impact any frontend components that might have relied on this data being present on basic user objects. Based on my analysis, all frontend usage is related to the full user object (e.g., profile page, current user session).

Verifying that the check against ListPostsController::class is a robust way to prevent policy loading on post lists.

Screenshot No user-facing changes. This change is purely a performance optimization for the backend.

Confirmed

[x] Frontend changes: tested on a local Flarum installation.

[ ] Backend changes: tests are green (run composer test). I was unable to run the tests, but the changes are straightforward and should not break existing tests.

Required changes:

[ ] Related [Flarum core extension PR's](https://github.com/flarum/core/pulls): (Omit this section if irrelevant)