### PR TITLE
[2.x] fix: Batch policy state loading to avoid one pivot query per serialized user

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -61,7 +61,41 @@ return [
         ->serializeToForum('fof-terms.date-format', 'fof-terms.date-format', 'strVal'),
 
     (new Extend\ApiResource(Resource\UserResource::class))
-        ->fields(Api\UserResourceFields::class),
+        ->fields(Api\UserResourceFields::class)
+        ->endpoint(Endpoint\Index::class, function (Endpoint\Index $endpoint) {
+            return $endpoint->eagerLoad(['fofTermsPolicies']);
+        }),
+
+    // Permission checks on a user (e.g. another extension's per-user
+    // serializer flags) run the permission group processor, which needs the
+    // user's accepted policies. Eager load them alongside the users these
+    // endpoints already load, so that neither the processor nor the policy
+    // state fields fall back to one lazy pivot query per serialized user.
+    (new Extend\ApiResource(Resource\DiscussionResource::class))
+        ->endpoint(Endpoint\Index::class, function (Endpoint\Index $endpoint) {
+            return $endpoint->eagerLoad([
+                'user.fofTermsPolicies',
+                'lastPostedUser.fofTermsPolicies',
+                'mostRelevantPost.user.fofTermsPolicies',
+            ]);
+        })
+        ->endpoint(Endpoint\Show::class, function (Endpoint\Show $endpoint) {
+            // Deliberately no `posts.user.*` here: eager loads apply to the
+            // primary model via loadMissing(), which would load a discussion's
+            // entire posts relation. Post stream users are covered by the
+            // posts index endpoint below.
+            return $endpoint->eagerLoad([
+                'user.fofTermsPolicies',
+                'lastPostedUser.fofTermsPolicies',
+                'firstPost.user.fofTermsPolicies',
+                'lastPost.user.fofTermsPolicies',
+            ]);
+        }),
+
+    (new Extend\ApiResource(Resource\PostResource::class))
+        ->endpoint(Endpoint\Index::class, function (Endpoint\Index $endpoint) {
+            return $endpoint->eagerLoad(['user.fofTermsPolicies']);
+        }),
 
     (new Extend\ApiResource(Resource\ForumResource::class))
         ->fields(Api\ForumResourceFields::class)

--- a/src/Api/PolicyStateBuffer.php
+++ b/src/Api/PolicyStateBuffer.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of fof/terms.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Terms\Api;
+
+use Flarum\User\User;
+use Illuminate\Database\Eloquent\Collection;
+
+/**
+ * Collects users while the API document is being built, so that their
+ * accepted policies can be loaded with a single query for all of them when
+ * the first deferred field value is resolved — instead of one lazy
+ * relationship load per serialized user.
+ *
+ * Mirrors the batching approach of Flarum's EloquentBuffer for relationships.
+ */
+class PolicyStateBuffer
+{
+    /**
+     * @var array<int, User>
+     */
+    protected static array $buffer = [];
+
+    public static function add(User $user): void
+    {
+        self::$buffer[spl_object_id($user)] = $user;
+    }
+
+    public static function loadPending(): void
+    {
+        $pending = array_filter(
+            self::$buffer,
+            fn (User $user) => !$user->relationLoaded('fofTermsPolicies')
+        );
+
+        self::$buffer = [];
+
+        if ($pending) {
+            (new Collection(array_values($pending)))->load('fofTermsPolicies');
+        }
+    }
+}

--- a/src/Api/UserResourceFields.php
+++ b/src/Api/UserResourceFields.php
@@ -29,19 +29,19 @@ class UserResourceFields
                 ->visible(
                     fn (User $user, Context $context) => $context->getActor()->can('seeFoFTermsPoliciesState', $user)
                 )
-                ->get(fn (User $user) => $this->policies->state($user)),
+                ->get($this->batched(fn (User $user) => $this->policies->state($user))),
 
             Schema\Boolean::make('fofTermsPoliciesHasUpdate')
                 ->visible(
                     fn (User $user, Context $context) => $context->getActor()->can('seeFoFTermsPoliciesState', $user)
                 )
-                ->get(fn (User $user) => $this->policies->hasPoliciesUpdate($user)),
+                ->get($this->batched(fn (User $user) => $this->policies->hasPoliciesUpdate($user))),
 
             Schema\Boolean::make('fofTermsPoliciesMustAccept')
                 ->visible(
                     fn (User $user, Context $context) => $context->getActor()->can('seeFoFTermsPoliciesState', $user)
                 )
-                ->get(fn (User $user) => $this->policies->mustAcceptNewPolicies($user)),
+                ->get($this->batched(fn (User $user) => $this->policies->mustAcceptNewPolicies($user))),
 
             Schema\Relationship\ToMany::make('fofTermsPolicies')
                 ->type('fof-terms-policies')
@@ -61,5 +61,23 @@ class UserResourceFields
         }
 
         return $fields;
+    }
+
+    /**
+     * Wrap a per-user getter so its value is resolved after the whole
+     * document has been visited, with the accepted policies of every
+     * buffered user loaded in one query instead of one query per user.
+     */
+    protected function batched(callable $callback): callable
+    {
+        return function (User $user) use ($callback) {
+            PolicyStateBuffer::add($user);
+
+            return function () use ($user, $callback) {
+                PolicyStateBuffer::loadPending();
+
+                return $callback($user);
+            };
+        };
     }
 }

--- a/tests/integration/api/PolicyStateQueryCountTest.php
+++ b/tests/integration/api/PolicyStateQueryCountTest.php
@@ -1,0 +1,186 @@
+<?php
+
+/*
+ * This file is part of fof/terms.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Terms\Tests\integration\api;
+
+use Carbon\Carbon;
+use Flarum\Api\Endpoint;
+use Flarum\Api\Resource\UserResource;
+use Flarum\Api\Schema;
+use Flarum\Discussion\Discussion;
+use Flarum\Extend;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use FoF\Terms\Policy;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * The per-user policy state fields lazy-loaded each user's accepted policies,
+ * issuing one pivot query per serialized user. On a discussion list viewed by
+ * an actor who can see policy states, that meant one query per distinct user
+ * on the page. These tests pin the batched behaviour: the pivot table must be
+ * queried a constant number of times regardless of how many users appear.
+ */
+class PolicyStateQueryCountTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('fof-terms');
+
+        $users = [$this->normalUser()];
+        $discussions = [];
+
+        // Five discussions, each started and last posted by a different user.
+        for ($i = 0; $i < 5; $i++) {
+            $userId = 3 + $i;
+
+            $users[] = [
+                'id'                 => $userId,
+                'username'           => 'poster'.$userId,
+                'email'              => 'poster'.$userId.'@machine.local',
+                'is_email_confirmed' => 1,
+                'password'           => 'foobar',
+            ];
+
+            $discussions[] = [
+                'id'                  => 1 + $i,
+                'title'               => 'Discussion '.$i,
+                'created_at'          => Carbon::createFromDate(2024, 1, 1 + $i)->toDateTimeString(),
+                'last_posted_at'      => Carbon::createFromDate(2024, 1, 1 + $i)->toDateTimeString(),
+                'user_id'             => $userId,
+                'last_posted_user_id' => $userId,
+                'comment_count'       => 1,
+            ];
+        }
+
+        $this->prepareDatabase([
+            User::class => $users,
+            Discussion::class => $discussions,
+            Policy::class => [
+                [
+                    'id'               => 1,
+                    'name'             => 'Terms of Service',
+                    'url'              => 'https://example.com/terms',
+                    'update_message'   => null,
+                    'terms_updated_at' => Carbon::parse('2024-01-01'),
+                    'optional'         => false,
+                    'sort'             => 0,
+                ],
+            ],
+        ]);
+    }
+
+    /**
+     * @return array{int, array} Pivot query count and the decoded response body.
+     */
+    private function listDiscussionsCountingPivotQueries(int $actorId): array
+    {
+        $this->app();
+
+        $db = $this->database();
+        $db->flushQueryLog();
+        $db->enableQueryLog();
+
+        $response = $this->send(
+            $this->request('GET', '/api/discussions', ['authenticatedAs' => $actorId])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $count = 0;
+
+        foreach ($db->getQueryLog() as $query) {
+            if (stripos($query['query'], 'fof_terms_policy_user') !== false) {
+                $count++;
+            }
+        }
+
+        $db->flushQueryLog();
+
+        return [$count, json_decode($response->getBody()->getContents(), true)];
+    }
+
+    #[Test]
+    public function policy_state_is_loaded_with_a_constant_number_of_queries_for_privileged_actors()
+    {
+        [$pivotQueries, $body] = $this->listDiscussionsCountingPivotQueries(1);
+
+        // Sanity: the state fields were actually serialized for the included users.
+        $serializedStates = 0;
+
+        foreach ($body['included'] ?? [] as $resource) {
+            if ($resource['type'] === 'users' && isset($resource['attributes']['fofTermsPoliciesState'])) {
+                $serializedStates++;
+            }
+        }
+
+        $this->assertGreaterThanOrEqual(5, $serializedStates, 'Expected policy state to be serialized for the discussion authors.');
+
+        // One eager load per relation path that materializes users (authors
+        // via the primary models, last posters via the relationship buffer) —
+        // constant regardless of how many users appear on the page.
+        $this->assertSame(
+            2,
+            $pivotQueries,
+            "Policy state must be eager loaded per relation path, not one query per user (got $pivotQueries for 5 users)."
+        );
+    }
+
+    #[Test]
+    public function permission_checks_on_serialized_users_do_not_query_per_user()
+    {
+        // Simulate what other extensions do in the wild (e.g. a per-user
+        // serializer flag calling $user->hasPermission()): each such call runs
+        // the permission group processor, which needs that user's accepted
+        // policies. Without eager loading this was one pivot query per user.
+        $this->extend(
+            (new Extend\ApiResource(UserResource::class))->fields(fn () => [
+                Schema\Boolean::make('fofTermsTestPerUserPermission')
+                    ->get(fn (User $user) => $user->hasPermission('viewForum')),
+            ])
+        );
+
+        [$pivotQueries] = $this->listDiscussionsCountingPivotQueries(1);
+
+        $this->assertLessThanOrEqual(
+            3,
+            $pivotQueries,
+            "Per-user permission checks must be served by the eager-loaded relation, not one pivot query per user (got $pivotQueries for 5 users)."
+        );
+    }
+
+    #[Test]
+    public function policy_state_is_not_loaded_per_user_for_unprivileged_actors()
+    {
+        [$pivotQueries, $body] = $this->listDiscussionsCountingPivotQueries(2);
+
+        // Sanity: a normal user sees no one else's policy state.
+        foreach ($body['included'] ?? [] as $resource) {
+            if ($resource['type'] === 'users' && $resource['id'] !== '2') {
+                $this->assertArrayNotHasKey('fofTermsPoliciesState', $resource['attributes'] ?? []);
+            }
+        }
+
+        // Two constant eager loads (authors + last posters), plus the
+        // PermissionGroupProcessor checking the actor's own acceptance state
+        // to enforce the guest downgrade — never one query per user.
+        $this->assertSame(
+            3,
+            $pivotQueries,
+            'Pivot queries must stay constant (eager loads + the actor\'s own enforcement check), not grow per user.'
+        );
+    }
+}

--- a/tests/integration/api/PolicyStateQueryCountTest.php
+++ b/tests/integration/api/PolicyStateQueryCountTest.php
@@ -12,7 +12,6 @@
 namespace FoF\Terms\Tests\integration\api;
 
 use Carbon\Carbon;
-use Flarum\Api\Endpoint;
 use Flarum\Api\Resource\UserResource;
 use Flarum\Api\Schema;
 use Flarum\Discussion\Discussion;
@@ -67,9 +66,9 @@ class PolicyStateQueryCountTest extends TestCase
         }
 
         $this->prepareDatabase([
-            User::class => $users,
+            User::class       => $users,
             Discussion::class => $discussions,
-            Policy::class => [
+            Policy::class     => [
                 [
                     'id'               => 1,
                     'name'             => 'Terms of Service',


### PR DESCRIPTION
## Problem

On endpoints that serialize many users (most visibly a discussion list viewed by a privileged actor), fof/terms issued one `fof_terms_policy_user` pivot query per distinct user on the page (~30 queries for a 20-discussion list on a busy forum). Two separate paths caused this:

1. **The per-user policy state fields** (`fofTermsPoliciesState`, `fofTermsPoliciesHasUpdate`, `fofTermsPoliciesMustAccept`) each lazy-loaded the user's accepted policies.
2. **The permission group processor**: any `hasPermission()`/`can()` call on a serialized user (e.g. another extension's per-user serializer flag) computes that user's permission groups, and the processor then checks that user's acceptance state to apply the guest downgrade — one lazy pivot query per user.

## Fix

1. The state fields now defer their values (Flarum's deferred field resolution) and buffer users via a new `PolicyStateBuffer`; the first resolved value loads the accepted policies of all buffered users in a single query — mirroring core's `EloquentBuffer` approach.
2. The discussion Index/Show, posts Index, and users Index endpoints now eager load `fofTermsPolicies` alongside the users they already load, so the permission group processor finds the relation in place. (`posts.user.*` is deliberately not eager loaded on discussion Show: endpoint eager loads apply to primary models via `loadMissing()`, which would load a discussion's entire posts relation. Post stream users are covered by the posts Index endpoint.)

## Measured

Real forum, admin actor, `/api/discussions?page[limit]=20`: extension queries **32 → 3** (constant, regardless of page size), total request queries 149 → 120.

## Tests

New `PolicyStateQueryCountTest` pins the constants: 2 pivot queries for a privileged actor over 5 distinct users, +1 for the actor's own enforcement check, and a test registering an ad-hoc per-user `hasPermission()` field to simulate the second path.

Related: the core half of this investigation was flarum/framework#4839.

Fixes #49.